### PR TITLE
fix threadsafe usage, remove excess newlines

### DIFF
--- a/src/GameAI/Algorithms/MonteCarlo/RandomSimulation.cs
+++ b/src/GameAI/Algorithms/MonteCarlo/RandomSimulation.cs
@@ -24,8 +24,6 @@ namespace GameAI.Algorithms.MonteCarlo
             IWinner<TPlayer>
         { }
         
-
-
         /// <summary>
         /// Returns the move found to have highest win-rate after performing, in parallel, the specified number of Monte-Carlo simulations on the input game.
         /// </summary>
@@ -44,13 +42,13 @@ namespace GameAI.Algorithms.MonteCarlo
 
                 (i, loop, localRandom) =>
             {
-                int moveIndex = localRandom.Value.Next(0, count);
+                int moveIndex = localRandom.Next(0, count);
                 TGame copy = game.DeepCopy();
                 copy.DoMove(legalMoves[moveIndex]);
 
                 while (!copy.IsGameOver())
                     copy.DoMove(
-                        copy.GetLegalMoves().RandomItem(localRandom.Value));
+                        copy.GetLegalMoves().RandomItem(localRandom));
 
                 Interlocked.Add(ref moveStats[moveIndex].executions, 1);
                 if (copy.IsWinner(aiPlayer))
@@ -62,7 +60,6 @@ namespace GameAI.Algorithms.MonteCarlo
                 (x) => { }
 
             );
-
             
             int bestMoveFound = 0;
             double bestScoreFound = 0f;
@@ -82,8 +79,6 @@ namespace GameAI.Algorithms.MonteCarlo
             return legalMoves[bestMoveFound];
 
         }
-
-
 
         /// <summary>
         /// Returns the move found to have highest win-rate after performing the specified number of Monte-Carlo simulations on the input game.
@@ -129,10 +124,6 @@ namespace GameAI.Algorithms.MonteCarlo
 
             return legalMoves[bestMoveFound];
         }
-
-
-
-
 
         private struct MoveStats
         {

--- a/src/GameAI/Algorithms/MonteCarlo/UCB1Tree.cs
+++ b/src/GameAI/Algorithms/MonteCarlo/UCB1Tree.cs
@@ -8,7 +8,6 @@ using GameAI.GameInterfaces;
 
 namespace GameAI.Algorithms.MonteCarlo
 {
-
     /// <summary>
     /// A method class for selecting moves in determinsitic, two-player, back-and-forth, zero-sum or zero-sum-tie games
     /// </summary>
@@ -38,6 +37,7 @@ namespace GameAI.Algorithms.MonteCarlo
             /// The move to perform the transition.
             /// </summary>
             public TMove Move;
+
             /// <summary>
             /// The hash of the resulting gamestate.
             /// </summary>
@@ -118,7 +118,7 @@ namespace GameAI.Algorithms.MonteCarlo
                         // EXPANSION
                         else
                         {
-                            copy.Transition(transitionsNoStats.RandomItem(localVars.random.Value));
+                            copy.Transition(transitionsNoStats.RandomItem(localVars.random));
 
                             Node n = new Node(copy.CurrentPlayer);
 
@@ -142,11 +142,8 @@ namespace GameAI.Algorithms.MonteCarlo
                     return localVars;
                 },
 
-
                 (x) => { }
                 );
-
-
 
             // Simulations are over. Pick the best move, then return it
             List<Transition> allTransitions = game.GetLegalTransitions();
@@ -161,7 +158,6 @@ namespace GameAI.Algorithms.MonteCarlo
                 Node n = tree[allTransitions[i].Hash];
                 //Console.WriteLine("Move {0}: plays-{1} wins-{2} plyr-{3}", i, n.plays, n.wins, n.player);
 
-
                 // **NOTE**
                 // The best move chosen is the move with gives the
                 // opponent the least number of victories
@@ -175,7 +171,6 @@ namespace GameAI.Algorithms.MonteCarlo
 
             return allTransitions[indexOfBestMoveFound];
         }
-
 
         /// <summary>
         /// Returns the best Transition discovered after performing the specified number of simulations, in parallel, on the game.
@@ -230,7 +225,7 @@ namespace GameAI.Algorithms.MonteCarlo
                         // EXPANSION
                         else
                         {
-                            copy.Transition(transitionsNoStats.RandomItem(localVars.random.Value));
+                            copy.Transition(transitionsNoStats.RandomItem(localVars.random));
 
                             Node n = new Node(copy.CurrentPlayer);
                             if (tree.TryAdd(copy.Hash, n)) localVars.path.Add(n);
@@ -252,7 +247,6 @@ namespace GameAI.Algorithms.MonteCarlo
 
                     return localVars;
                 },
-
 
                 (x) => { }
                 );
@@ -285,23 +279,6 @@ namespace GameAI.Algorithms.MonteCarlo
 
             return allTransitions[indexOfBestMoveFound];
         }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
         /// <summary>
         /// Returns the best Transition discovered after performing the specified number of simulations on the game.
@@ -394,7 +371,6 @@ namespace GameAI.Algorithms.MonteCarlo
                 Node n = tree[allTransitions[i].Hash];
                 //Console.WriteLine("Move {0}: plays-{1} wins-{2} plyr-{3}", i, n.plays, n.wins, n.player);
 
-
                 // **NOTE**
                 // The best move chosen is the move with gives the
                 // opponent the least number of victories
@@ -408,14 +384,6 @@ namespace GameAI.Algorithms.MonteCarlo
 
             return allTransitions[indexOfBestMoveFound];
         }
-
-
-
-
-
-
-
-
 
         /// <summary>
         /// Returns the best Transition discovered after performing the specified number of simulations on the game.
@@ -507,7 +475,6 @@ namespace GameAI.Algorithms.MonteCarlo
                 Node n = tree[allTransitions[i].Hash];
                 //Console.WriteLine("Move {0}: plays-{1} wins-{2} plyr-{3}", i, n.plays, n.wins, n.player);
 
-
                 // **NOTE**
                 // The best move chosen is the move with gives the
                 // opponent the least number of victories
@@ -522,18 +489,10 @@ namespace GameAI.Algorithms.MonteCarlo
             return allTransitions[indexOfBestMoveFound];
         }
 
-
-
-
-
-
-
         private static double UCB1(double childWins, double childPlays, double parentPlays)
         {
             return (childWins / childPlays) + Math.Sqrt(2f * Math.Log(parentPlays) / childPlays);
         }
-
-
 
         private class Node
         {
@@ -563,14 +522,12 @@ namespace GameAI.Algorithms.MonteCarlo
             }
         }
 
-
-
         private class ThreadLocalVars
         {
-            internal ThreadLocal<Random> random;
+            internal Random random;
             internal List<Node> path;
 
-            internal ThreadLocalVars(ThreadLocal<Random> random, List<Node> path)
+            internal ThreadLocalVars(Random random, List<Node> path)
             {
                 this.random = random;
                 this.path = path;

--- a/src/GameAI/GameAI.csproj
+++ b/src/GameAI/GameAI.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>GameAI</RootNamespace>
     <AssemblyName>GameAI</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>

--- a/src/GameAI/RandomFactory.cs
+++ b/src/GameAI/RandomFactory.cs
@@ -1,14 +1,18 @@
 ﻿using System;
-using System.Threading;
 
 namespace GameAI
 {
     internal static class RandomFactory
     {
         private static readonly Random GlobalRandom = new Random();
+        private static readonly object Lock = new object();
 
-        internal static ThreadLocal<Random> Create()
-            => new ThreadLocal<Random>(
-                () => new Random(GlobalRandom.Next()));
+        internal static Random Create()
+        {
+            lock (Lock)
+            {
+                return new Random(GlobalRandom.Next());
+            }
+        }
     }
 }


### PR DESCRIPTION
- Adds global lock to generate threadsafe `Random` instances
- Removes excess `ThreadLocal` wrapper in `Parallel.For` loop (it is already generated thread-locally)
- Visual Studio was barking about the .NET version, so I moved it to their recommended 4.6.1
- Removes excess newlines